### PR TITLE
Ignore CRC Error checkbox 

### DIFF
--- a/BK7231Flasher/BK7231Flasher.cs
+++ b/BK7231Flasher/BK7231Flasher.cs
@@ -432,6 +432,12 @@ namespace BK7231Flasher
         {
             bSkipKeyCheck = b;
         }
+        bool bIgnoreCRCErr=false;
+        public void setIgnoreCRCErr(bool b)
+        {
+            bIgnoreCRCErr = b;
+        }
+        
         public void setOverwriteBootloader(bool b)
         {
             bOverwriteBootloader = b;
@@ -1455,6 +1461,10 @@ namespace BK7231Flasher
                 addError("Send by BK " + formatHex(bk_crc) + ", our CRC " + formatHex(our_crc) + Environment.NewLine);
                 addError("Maybe you have wrong chip type set?" + Environment.NewLine);
                 addError("Did you set BK7231T but have in reality BK7231N or BK7231M?" + Environment.NewLine);
+                if (bIgnoreCRCErr) {
+                    addWarning("IgnoreCRCErr checked, bin will be saved even if there is a crc mismatch" + Environment.NewLine);
+                    return true;
+                }
                 return false;
             }
             addSuccess("CRC matches " + formatHex(bk_crc) + "!" + Environment.NewLine);

--- a/BK7231Flasher/FormMain.Designer.cs
+++ b/BK7231Flasher/FormMain.Designer.cs
@@ -40,6 +40,7 @@
             this.comboBoxFirmware = new System.Windows.Forms.ComboBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.chkIgnoreCRCErr = new System.Windows.Forms.CheckBox();
             this.buttonCustomOperation = new System.Windows.Forms.Button();
             this.checkBoxSkipKeyCheck = new System.Windows.Forms.CheckBox();
             this.checkBoxOverwriteBootloader = new System.Windows.Forms.CheckBox();
@@ -273,6 +274,7 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.chkIgnoreCRCErr);
             this.tabPage1.Controls.Add(this.buttonCustomOperation);
             this.tabPage1.Controls.Add(this.checkBoxSkipKeyCheck);
             this.tabPage1.Controls.Add(this.checkBoxOverwriteBootloader);
@@ -316,6 +318,17 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "Flasher";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // chkIgnoreCRCErr
+            // 
+            this.chkIgnoreCRCErr.AutoSize = true;
+            this.chkIgnoreCRCErr.Location = new System.Drawing.Point(772, 22);
+            this.chkIgnoreCRCErr.Name = "chkIgnoreCRCErr";
+            this.chkIgnoreCRCErr.Size = new System.Drawing.Size(106, 17);
+            this.chkIgnoreCRCErr.TabIndex = 37;
+            this.chkIgnoreCRCErr.Text = "Ignore CRC Error";
+            this.chkIgnoreCRCErr.UseVisualStyleBackColor = true;
+            this.chkIgnoreCRCErr.CheckedChanged += new System.EventHandler(this.chkIgnoreCRCErr_CheckedChanged);
             // 
             // buttonCustomOperation
             // 
@@ -1728,6 +1741,7 @@
         private System.Windows.Forms.ListBox listBoxOTA;
         private System.Windows.Forms.Label label34;
         private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.CheckBox chkIgnoreCRCErr;
     }
 }
 

--- a/BK7231Flasher/FormMain.cs
+++ b/BK7231Flasher/FormMain.cs
@@ -422,6 +422,8 @@ namespace BK7231Flasher
             flasher.setReadTimeOutMultForSerialClass(cfg_readTimeOutMultForSerialClass);
             flasher.setOverwriteBootloader(checkBoxOverwriteBootloader.Checked);
             flasher.setSkipKeyCheck(checkBoxSkipKeyCheck.Checked);
+            flasher.setIgnoreCRCErr(chkIgnoreCRCErr.Checked);
+            
         }
         
         void testWrite()
@@ -1024,6 +1026,7 @@ namespace BK7231Flasher
             checkBoxOverwriteBootloader.Visible = b;
             checkBoxSkipKeyCheck.Visible = b;
             buttonCustomOperation.Visible = b;
+            chkIgnoreCRCErr.Visible = b;
         }
         
         private void buttonOpenBackupsDir_Click(object sender, EventArgs e)
@@ -1494,6 +1497,11 @@ namespace BK7231Flasher
             refreshOTAs();
         }
         void refreshOTAs()
+        {
+
+        }
+
+        private void chkIgnoreCRCErr_CheckedChanged(object sender, EventArgs e)
         {
 
         }


### PR DESCRIPTION
I added Ignore CRC Error checkbox (advanced mode) to allow save bin even if there is CRC mismatch on read

Reason: It has happened to me several times that it returned a CRC error but I still needed the bin. I don't know the reason for the incorrect CRC, I had the processor selected correctly. Anyway, I found out that despite the CRC error reported by the flasher, the downloaded BIN (after activating the checkbox) was fine.
Maybe this can be useful to someone else.