### PR TITLE
isolate custom write from _QIO_ handling, match only on filename not path for normal write

### DIFF
--- a/BK7231Flasher/CommandLineRunner.cs
+++ b/BK7231Flasher/CommandLineRunner.cs
@@ -467,6 +467,7 @@ namespace BK7231Flasher
             int startSector = ToStartSector(chipType, ofs);
             int sectors = len / BK7231Flasher.SECTOR_SIZE;
 
+            flasher.setCustomWriteMode(true);
             flasher.doReadAndWrite(startSector, sectors, writeFile, WriteMode.OnlyWrite);
 
             Console.WriteLine("\nCustom write completed successfully.");

--- a/BK7231Flasher/Flashers/BK7231Flasher.cs
+++ b/BK7231Flasher/Flashers/BK7231Flasher.cs
@@ -1426,6 +1426,13 @@ namespace BK7231Flasher
             return true;
         }
 
+        static bool FileNameHasQioMarker(string sourceFileName)
+        {
+            string fileName = Path.GetFileName(sourceFileName);
+            return !string.IsNullOrEmpty(fileName) &&
+                fileName.IndexOf("_QIO_", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
         bool doReadAndWriteInternal(int startSector, int sectors, string sourceFileName, WriteMode rwMode)
         {
             logger.setProgress(0, sectors);
@@ -1484,7 +1491,7 @@ namespace BK7231Flasher
                 }
                 addSuccess("Loaded " + data.Length + " bytes from " + sourceFileName + "..." + Environment.NewLine);
                 bool bSkipBootloader = false;
-                if (sourceFileName.Contains("_QIO_"))
+                if (!bCustomWriteMode && FileNameHasQioMarker(sourceFileName))
                 {
                     if(bOverwriteBootloader == false && (chipType == BKType.BK7231N || chipType == BKType.BK7231M))
                     {
@@ -1507,6 +1514,14 @@ namespace BK7231Flasher
                 if (bSkipBootloader && startSector == BK7231Flasher.BOOTLOADER_SIZE)
                 {
                     // very hacky, but skip bootloader
+                    if (data.Length <= startSector)
+                    {
+                        addError("Cannot skip QIO bootloader area because the file is only "
+                            + data.Length + " bytes, but the bootloader skip size is "
+                            + startSector + " bytes." + Environment.NewLine);
+                        return false;
+                    }
+
                     int length = data.Length - startSector;
                     byte[] newData = new byte[length];
                     Array.Copy(data, startSector, newData, 0, length);

--- a/BK7231Flasher/Flashers/BK7231Flasher.cs
+++ b/BK7231Flasher/Flashers/BK7231Flasher.cs
@@ -1430,7 +1430,7 @@ namespace BK7231Flasher
         {
             string fileName = Path.GetFileName(sourceFileName);
             return !string.IsNullOrEmpty(fileName) &&
-                fileName.IndexOf("_QIO_", StringComparison.OrdinalIgnoreCase) >= 0;
+                fileName.IndexOf("_QIO_", StringComparison.Ordinal) >= 0;
         }
 
         bool doReadAndWriteInternal(int startSector, int sectors, string sourceFileName, WriteMode rwMode)

--- a/BK7231Flasher/Flashers/BaseFlasher.cs
+++ b/BK7231Flasher/Flashers/BaseFlasher.cs
@@ -81,6 +81,7 @@ namespace BK7231Flasher
         protected bool bOverwriteBootloader = false;
         protected bool bSkipKeyCheck;
         protected bool bIgnoreCRCErr = false;
+        protected bool bCustomWriteMode = false;
         protected SerialPort serial;
         protected string serialName;
         protected BKType chipType = BKType.BK7231N;
@@ -185,6 +186,10 @@ namespace BK7231Flasher
         public void setOverwriteBootloader(bool b)
         {
             bOverwriteBootloader = b;
+        }
+        public void setCustomWriteMode(bool b)
+        {
+            bCustomWriteMode = b;
         }
         public void setReadTimeOutMultForSerialClass(float f)
         {

--- a/BK7231Flasher/FormMain.cs
+++ b/BK7231Flasher/FormMain.cs
@@ -635,6 +635,7 @@ namespace BK7231Flasher
                 startSector = getBackupStartSectorForCurrentPlatform();
                 sectors = getBackupSectorCountForCurrentPlatform();
             }
+            flasher.setCustomWriteMode(parms != null);
             flasher.doReadAndWrite(startSector, sectors, chosenSourceFile, WriteMode.OnlyWrite);
             worker = null;
             //setButtonReadLabel(label_startRead);


### PR DESCRIPTION
custom write no longer treats _QIO_ filenames as full-image writes
standard write behaviour is preserved
_QIO_ matching is now filename only

fixes #125 