### PR TITLE
Harden LAN scanner discovery and device classification

### DIFF
--- a/BK7231Flasher/FormMain.Designer.cs
+++ b/BK7231Flasher/FormMain.Designer.cs
@@ -1691,7 +1691,7 @@ namespace BK7231Flasher
 			this.buttonPickSubnet.Name = "buttonPickSubnet";
 			this.buttonPickSubnet.Size = new System.Drawing.Size(84, 23);
 			this.buttonPickSubnet.TabIndex = 21;
-			this.buttonPickSubnet.Text = "Subnet";
+			this.buttonPickSubnet.Text = "Local NIC...";
 			this.buttonPickSubnet.UseVisualStyleBackColor = true;
 			this.buttonPickSubnet.Click += new System.EventHandler(this.buttonPickSubnet_Click);
 			// 
@@ -1729,7 +1729,7 @@ namespace BK7231Flasher
 			this.textBoxEndIP.Name = "textBoxEndIP";
 			this.textBoxEndIP.Size = new System.Drawing.Size(169, 20);
 			this.textBoxEndIP.TabIndex = 3;
-			this.textBoxEndIP.Text = "192.168.0.255";
+			this.textBoxEndIP.Text = "192.168.0.254";
 			this.textBoxEndIP.TextChanged += new System.EventHandler(this.textBoxEndIP_TextChanged);
 			// 
 			// label22
@@ -1747,7 +1747,7 @@ namespace BK7231Flasher
 			this.textBoxStartIP.Name = "textBoxStartIP";
 			this.textBoxStartIP.Size = new System.Drawing.Size(169, 20);
 			this.textBoxStartIP.TabIndex = 1;
-			this.textBoxStartIP.Text = "192.168.0.150";
+			this.textBoxStartIP.Text = "192.168.0.1";
 			this.textBoxStartIP.TextChanged += new System.EventHandler(this.textBoxStartIP_TextChanged);
 			// 
 			// label21

--- a/BK7231Flasher/FormMain.Designer.cs
+++ b/BK7231Flasher/FormMain.Designer.cs
@@ -1628,10 +1628,10 @@ namespace BK7231Flasher
 			this.label24.AutoSize = true;
 			this.label24.Location = new System.Drawing.Point(8, 12);
 			this.label24.Name = "label24";
-			this.label24.Size = new System.Drawing.Size(474, 13);
+			this.label24.Size = new System.Drawing.Size(712, 13);
 			this.label24.TabIndex = 8;
-			this.label24.Text = "Scan for OpenBeken and Tasmota devices. Extra attempts retry only addresses that " +
-    "did not respond.";
+			this.label24.Text = "Scan for OpenBeken and Tasmota devices. Starting a scan clears previous results; " +
+    "extra attempts retry only addresses that did not respond.";
 			// 
 			// listView1
 			// 

--- a/BK7231Flasher/FormMain.Designer.cs
+++ b/BK7231Flasher/FormMain.Designer.cs
@@ -1538,7 +1538,7 @@ namespace BK7231Flasher
 			this.textBoxIPScannerPass.Name = "textBoxIPScannerPass";
 			this.textBoxIPScannerPass.Size = new System.Drawing.Size(151, 20);
 			this.textBoxIPScannerPass.TabIndex = 19;
-			this.textBoxIPScannerPass.TextChanged += new System.EventHandler(this.textBoxIPScannerPass_TextChanged);
+			this.textBoxIPScannerPass.UseSystemPasswordChar = true;
 			// 
 			// label31
 			// 

--- a/BK7231Flasher/FormMain.Designer.cs
+++ b/BK7231Flasher/FormMain.Designer.cs
@@ -1572,16 +1572,16 @@ namespace BK7231Flasher
 			this.textBoxBoxScannerRetries.Name = "textBoxBoxScannerRetries";
 			this.textBoxBoxScannerRetries.Size = new System.Drawing.Size(44, 20);
 			this.textBoxBoxScannerRetries.TabIndex = 15;
-			this.textBoxBoxScannerRetries.Text = "5";
+			this.textBoxBoxScannerRetries.Text = "1";
 			// 
 			// label28
 			// 
 			this.label28.AutoSize = true;
-			this.label28.Location = new System.Drawing.Point(563, 45);
+			this.label28.Location = new System.Drawing.Point(548, 45);
 			this.label28.Name = "label28";
-			this.label28.Size = new System.Drawing.Size(39, 13);
+			this.label28.Size = new System.Drawing.Size(54, 13);
 			this.label28.TabIndex = 14;
-			this.label28.Text = "Loops:";
+			this.label28.Text = "Attempts:";
 			// 
 			// label29
 			// 
@@ -1628,10 +1628,10 @@ namespace BK7231Flasher
 			this.label24.AutoSize = true;
 			this.label24.Location = new System.Drawing.Point(8, 12);
 			this.label24.Name = "label24";
-			this.label24.Size = new System.Drawing.Size(747, 13);
+			this.label24.Size = new System.Drawing.Size(474, 13);
 			this.label24.TabIndex = 8;
-			this.label24.Text = "Here you can scan your LAN for OpenBeken and Tasmota devices. Scanner will first " +
-    "do a quick, unprecise loop and then some slower, more precise checks.\r\n";
+			this.label24.Text = "Scan for OpenBeken and Tasmota devices. Extra attempts retry only addresses that " +
+    "did not respond.";
 			// 
 			// listView1
 			// 

--- a/BK7231Flasher/FormMain.Designer.cs
+++ b/BK7231Flasher/FormMain.Designer.cs
@@ -1568,16 +1568,16 @@ namespace BK7231Flasher
 			// 
 			// textBoxBoxScannerRetries
 			// 
-			this.textBoxBoxScannerRetries.Location = new System.Drawing.Point(612, 42);
+			this.textBoxBoxScannerRetries.Location = new System.Drawing.Point(623, 42);
 			this.textBoxBoxScannerRetries.Name = "textBoxBoxScannerRetries";
-			this.textBoxBoxScannerRetries.Size = new System.Drawing.Size(44, 20);
+			this.textBoxBoxScannerRetries.Size = new System.Drawing.Size(33, 20);
 			this.textBoxBoxScannerRetries.TabIndex = 15;
 			this.textBoxBoxScannerRetries.Text = "1";
 			// 
 			// label28
 			// 
 			this.label28.AutoSize = true;
-			this.label28.Location = new System.Drawing.Point(548, 45);
+			this.label28.Location = new System.Drawing.Point(563, 45);
 			this.label28.Name = "label28";
 			this.label28.Size = new System.Drawing.Size(54, 13);
 			this.label28.TabIndex = 14;

--- a/BK7231Flasher/FormMain.Designer.cs
+++ b/BK7231Flasher/FormMain.Designer.cs
@@ -1524,11 +1524,11 @@ namespace BK7231Flasher
 			// buttonIPScannerOpenDir
 			// 
 			this.buttonIPScannerOpenDir.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.buttonIPScannerOpenDir.Location = new System.Drawing.Point(14, 442);
+			this.buttonIPScannerOpenDir.Location = new System.Drawing.Point(176, 412);
 			this.buttonIPScannerOpenDir.Name = "buttonIPScannerOpenDir";
 			this.buttonIPScannerOpenDir.Size = new System.Drawing.Size(156, 23);
 			this.buttonIPScannerOpenDir.TabIndex = 20;
-			this.buttonIPScannerOpenDir.Text = "Open backups dir";
+			this.buttonIPScannerOpenDir.Text = "Open backup folder";
 			this.buttonIPScannerOpenDir.UseVisualStyleBackColor = true;
 			this.buttonIPScannerOpenDir.Click += new System.EventHandler(this.buttonIPScannerOpenDir_Click);
 			// 
@@ -1562,13 +1562,13 @@ namespace BK7231Flasher
 			this.label30.AutoSize = true;
 			this.label30.Location = new System.Drawing.Point(11, 73);
 			this.label30.Name = "label30";
-			this.label30.Size = new System.Drawing.Size(60, 13);
+			this.label30.Size = new System.Drawing.Size(58, 13);
 			this.label30.TabIndex = 16;
-			this.label30.Text = "UserName:";
+			this.label30.Text = "Username:";
 			// 
 			// textBoxBoxScannerRetries
 			// 
-			this.textBoxBoxScannerRetries.Location = new System.Drawing.Point(623, 42);
+			this.textBoxBoxScannerRetries.Location = new System.Drawing.Point(623, 70);
 			this.textBoxBoxScannerRetries.Name = "textBoxBoxScannerRetries";
 			this.textBoxBoxScannerRetries.Size = new System.Drawing.Size(33, 20);
 			this.textBoxBoxScannerRetries.TabIndex = 15;
@@ -1577,7 +1577,7 @@ namespace BK7231Flasher
 			// label28
 			// 
 			this.label28.AutoSize = true;
-			this.label28.Location = new System.Drawing.Point(563, 45);
+			this.label28.Location = new System.Drawing.Point(563, 73);
 			this.label28.Name = "label28";
 			this.label28.Size = new System.Drawing.Size(54, 13);
 			this.label28.TabIndex = 14;
@@ -1589,19 +1589,19 @@ namespace BK7231Flasher
 			this.label29.AutoSize = true;
 			this.label29.Location = new System.Drawing.Point(12, 396);
 			this.label29.Name = "label29";
-			this.label29.Size = new System.Drawing.Size(353, 13);
+			this.label29.Size = new System.Drawing.Size(425, 13);
 			this.label29.TabIndex = 13;
-			this.label29.Text = "Here you can automatically download CFG backup for all devices from list";
+			this.label29.Text = "Configuration backups: Save configuration data for all detected devices.";
 			// 
 			// labelMassBackupProgress
 			// 
 			this.labelMassBackupProgress.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			this.labelMassBackupProgress.AutoSize = true;
-			this.labelMassBackupProgress.Location = new System.Drawing.Point(176, 412);
+			this.labelMassBackupProgress.Location = new System.Drawing.Point(340, 417);
 			this.labelMassBackupProgress.Name = "labelMassBackupProgress";
-			this.labelMassBackupProgress.Size = new System.Drawing.Size(76, 13);
+			this.labelMassBackupProgress.Size = new System.Drawing.Size(59, 13);
 			this.labelMassBackupProgress.TabIndex = 11;
-			this.labelMassBackupProgress.Text = "Doing nothing.";
+			this.labelMassBackupProgress.Text = "Status: Idle";
 			// 
 			// buttonStartMassBackup
 			// 
@@ -1610,7 +1610,7 @@ namespace BK7231Flasher
 			this.buttonStartMassBackup.Name = "buttonStartMassBackup";
 			this.buttonStartMassBackup.Size = new System.Drawing.Size(156, 23);
 			this.buttonStartMassBackup.TabIndex = 10;
-			this.buttonStartMassBackup.Text = "Start mass CFG backup";
+			this.buttonStartMassBackup.Text = "Back up configurations";
 			this.buttonStartMassBackup.UseVisualStyleBackColor = true;
 			this.buttonStartMassBackup.Click += new System.EventHandler(this.buttonStartMassBackup_Click);
 			// 
@@ -1619,19 +1619,20 @@ namespace BK7231Flasher
 			this.labelScanState.AutoSize = true;
 			this.labelScanState.Location = new System.Drawing.Point(12, 101);
 			this.labelScanState.Name = "labelScanState";
-			this.labelScanState.Size = new System.Drawing.Size(61, 13);
+			this.labelScanState.Size = new System.Drawing.Size(87, 13);
 			this.labelScanState.TabIndex = 9;
-			this.labelScanState.Text = "Scan state:";
+			this.labelScanState.Text = "Scan status: Idle";
 			// 
 			// label24
 			// 
 			this.label24.AutoSize = true;
-			this.label24.Location = new System.Drawing.Point(8, 12);
+			this.label24.Location = new System.Drawing.Point(8, 6);
 			this.label24.Name = "label24";
-			this.label24.Size = new System.Drawing.Size(712, 13);
+			this.label24.Size = new System.Drawing.Size(638, 26);
 			this.label24.TabIndex = 8;
-			this.label24.Text = "Scan for OpenBeken and Tasmota devices. Starting a scan clears previous results; " +
-    "extra attempts retry only addresses that did not respond.";
+			this.label24.Text = "Discover OpenBeken and Tasmota devices on your local network.\r\nStarting a new sc" +
+    "an clears the current results. Additional attempts retry addresses that did not" +
+    " respond.";
 			// 
 			// listView1
 			// 
@@ -1647,67 +1648,68 @@ namespace BK7231Flasher
             this.columnHeader5});
 			this.listView1.FullRowSelect = true;
 			this.listView1.HideSelection = false;
-			this.listView1.Location = new System.Drawing.Point(11, 117);
+			this.listView1.Location = new System.Drawing.Point(11, 121);
 			this.listView1.Name = "listView1";
-			this.listView1.Size = new System.Drawing.Size(656, 272);
+			this.listView1.Size = new System.Drawing.Size(880, 268);
 			this.listView1.TabIndex = 7;
 			this.listView1.UseCompatibleStateImageBehavior = false;
 			this.listView1.View = System.Windows.Forms.View.Details;
 			this.listView1.MouseClick += new System.Windows.Forms.MouseEventHandler(this.listView1_MouseClick);
+			this.listView1.Resize += new System.EventHandler(this.listView1_Resize);
 			// 
 			// columnID
 			// 
-			this.columnID.Text = "Idx";
+			this.columnID.Text = "#";
 			this.columnID.Width = 36;
 			// 
 			// columnHeader1
 			// 
 			this.columnHeader1.Text = "IP";
-			this.columnHeader1.Width = 100;
+			this.columnHeader1.Width = 110;
 			// 
 			// columnHeader2
 			// 
-			this.columnHeader2.Text = "Short Name";
-			this.columnHeader2.Width = 120;
+			this.columnHeader2.Text = "Device name";
+			this.columnHeader2.Width = 200;
 			// 
 			// columnHeader3
 			// 
 			this.columnHeader3.Text = "Chipset";
-			this.columnHeader3.Width = 78;
+			this.columnHeader3.Width = 90;
 			// 
 			// columnHeader4
 			// 
 			this.columnHeader4.Text = "MAC";
-			this.columnHeader4.Width = 111;
+			this.columnHeader4.Width = 125;
 			// 
 			// columnHeader5
 			// 
 			this.columnHeader5.Text = "Build";
-			this.columnHeader5.Width = 122;
+			this.columnHeader5.Width = 313;
 			// 
 			// buttonPickSubnet
 			// 
-			this.buttonPickSubnet.Location = new System.Drawing.Point(807, 40);
+			this.buttonPickSubnet.Location = new System.Drawing.Point(458, 40);
 			this.buttonPickSubnet.Name = "buttonPickSubnet";
-			this.buttonPickSubnet.Size = new System.Drawing.Size(84, 23);
+			this.buttonPickSubnet.Size = new System.Drawing.Size(117, 23);
 			this.buttonPickSubnet.TabIndex = 21;
-			this.buttonPickSubnet.Text = "Local NIC...";
+			this.buttonPickSubnet.Text = "Select subnet...";
 			this.buttonPickSubnet.UseVisualStyleBackColor = true;
 			this.buttonPickSubnet.Click += new System.EventHandler(this.buttonPickSubnet_Click);
 			// 
 			// buttonStartScan
 			// 
-			this.buttonStartScan.Location = new System.Drawing.Point(662, 40);
+			this.buttonStartScan.Location = new System.Drawing.Point(752, 70);
 			this.buttonStartScan.Name = "buttonStartScan";
 			this.buttonStartScan.Size = new System.Drawing.Size(139, 23);
 			this.buttonStartScan.TabIndex = 6;
-			this.buttonStartScan.Text = "Start";
+			this.buttonStartScan.Text = "Start scan";
 			this.buttonStartScan.UseVisualStyleBackColor = true;
 			this.buttonStartScan.Click += new System.EventHandler(this.buttonStartScan_Click);
 			// 
 			// textBoxScannerThreads
 			// 
-			this.textBoxScannerThreads.Location = new System.Drawing.Point(513, 42);
+			this.textBoxScannerThreads.Location = new System.Drawing.Point(513, 70);
 			this.textBoxScannerThreads.Name = "textBoxScannerThreads";
 			this.textBoxScannerThreads.Size = new System.Drawing.Size(44, 20);
 			this.textBoxScannerThreads.TabIndex = 5;
@@ -1717,7 +1719,7 @@ namespace BK7231Flasher
 			// label23
 			// 
 			this.label23.AutoSize = true;
-			this.label23.Location = new System.Drawing.Point(458, 45);
+			this.label23.Location = new System.Drawing.Point(458, 73);
 			this.label23.Name = "label23";
 			this.label23.Size = new System.Drawing.Size(49, 13);
 			this.label23.TabIndex = 4;

--- a/BK7231Flasher/FormMain.cs
+++ b/BK7231Flasher/FormMain.cs
@@ -191,6 +191,10 @@ namespace BK7231Flasher
             }
 
             settings = MySettings.CreateAndLoad("settings.cfg");
+            if (settings.RemoveKey("ScannerPass"))
+            {
+                settings.Save("settings.cfg");
+            }
             List<string> recentIPs = settings.getRecentIPs();
             for(int i = recentIPs.Count-1; i >= 0; i--)
             {
@@ -301,10 +305,6 @@ namespace BK7231Flasher
             if (settings.HasKey("bAllowBackupRestore"))
             {
                 checkBoxAllowBackup.Checked = settings.FindKeyValueBool("bAllowBackupRestore");
-            }
-            if (settings.HasKey("ScannerPass"))
-            {
-                textBoxIPScannerPass.Text = settings.FindKeyValue("ScannerPass","admin");
             }
             if (settings.HasKey("ScannerUser"))
             {
@@ -2188,11 +2188,6 @@ namespace BK7231Flasher
         private void textBoxIPScannerUser_TextChanged(object sender, EventArgs e)
         {
             setSettingsKeyAndSave("ScannerUser", textBoxIPScannerUser.Text);
-        }
-
-        private void textBoxIPScannerPass_TextChanged(object sender, EventArgs e)
-        {
-            setSettingsKeyAndSave("ScannerPass", textBoxIPScannerPass.Text);
         }
 
         private void textBoxStartIP_TextChanged(object sender, EventArgs e)

--- a/BK7231Flasher/FormMain.cs
+++ b/BK7231Flasher/FormMain.cs
@@ -2173,7 +2173,7 @@ namespace BK7231Flasher
         }
         private void onMassBackupFinish(int totalErrors, int totalRetries)
         {
-            onMassBackupProgress("Ready! "+totalErrors+" errors, " + totalRetries + " retries.");
+            onMassBackupProgress("Complete. Errors: " + totalErrors + "; retries: " + totalRetries + ".");
             Singleton.labelMassBackupProgress.Invoke((MethodInvoker)delegate {
                 buttonStartMassBackup.Enabled = true;
             });
@@ -2181,7 +2181,7 @@ namespace BK7231Flasher
         private void onMassBackupProgress(string txt)
         {
             Singleton.labelMassBackupProgress.Invoke((MethodInvoker)delegate {
-                labelMassBackupProgress.Text = txt;
+                labelMassBackupProgress.Text = "Status: " + txt;
             });
         }
 

--- a/BK7231Flasher/FormMain.cs
+++ b/BK7231Flasher/FormMain.cs
@@ -2010,6 +2010,18 @@ namespace BK7231Flasher
             setMaxWorkersCountFromGUI();
         }
 
+        private static bool sendRebootIfConfirmed(
+            OBKDeviceAPI device,
+            DialogResult confirmation)
+        {
+            if (device == null || confirmation != DialogResult.Yes)
+            {
+                return false;
+            }
+            device.sendCmnd("reboot", null);
+            return true;
+        }
+
         private void listView1_MouseClick(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Right)
@@ -2046,8 +2058,13 @@ namespace BK7231Flasher
                 ToolStripMenuItem rebootMenuItem = new ToolStripMenuItem("Reboot");
                 rebootMenuItem.Click += (s, args) =>
                 {
-                    OBKDeviceAPI devo = selectedItem.Tag as OBKDeviceAPI;
-                    devo.sendCmnd("reboot",null);
+                    DialogResult confirmation = MessageBox.Show(
+                        "Reboot device at " + dev.getAdr() + "?",
+                        "Confirm reboot",
+                        MessageBoxButtons.YesNo,
+                        MessageBoxIcon.Warning,
+                        MessageBoxDefaultButton.Button2);
+                    sendRebootIfConfirmed(dev, confirmation);
                 };
                 contextMenu.Items.Add(rebootMenuItem);
 

--- a/BK7231Flasher/FormMain.cs
+++ b/BK7231Flasher/FormMain.cs
@@ -2014,9 +2014,17 @@ namespace BK7231Flasher
         {
             if (e.Button == MouseButtons.Right)
             {
-                ListViewItem selectedItem = listView1.FocusedItem;
+                ListViewItem selectedItem = listView1.GetItemAt(e.X, e.Y);
+                OBKDeviceAPI dev = selectedItem?.Tag as OBKDeviceAPI;
+                if (selectedItem == null || dev == null)
+                {
+                    return;
+                }
+                selectedItem.Selected = true;
+                selectedItem.Focused = true;
 
                 ContextMenuStrip contextMenu = new ContextMenuStrip();
+                contextMenu.Closed += (s, args) => contextMenu.Dispose();
 
                 ToolStripMenuItem openPageMenuItem = new ToolStripMenuItem("Open page");
                 openPageMenuItem.Click += (s, args) =>
@@ -2043,7 +2051,6 @@ namespace BK7231Flasher
                 };
                 contextMenu.Items.Add(rebootMenuItem);
 
-                OBKDeviceAPI dev = selectedItem.Tag as OBKDeviceAPI;
                 for (int i = 0; i < dev.getPowerSlotsCount(); i++)
                 {
                     int slotIndex = i+1; 

--- a/BK7231Flasher/FormMain_Net_Scanner.cs
+++ b/BK7231Flasher/FormMain_Net_Scanner.cs
@@ -35,31 +35,27 @@ namespace BK7231Flasher
                 scan.requestStop();
                 return;
             }
-            IPAddress tmp;
-            if(IPAddress.TryParse(textBoxStartIP.Text, out tmp) == false)
+            uint startAddress;
+            uint endAddress;
+            string rangeError;
+            if (OBKScanner.tryParseRange(textBoxStartIP.Text, textBoxEndIP.Text,
+                out startAddress, out endAddress, out rangeError) == false)
             {
-                MessageBox.Show("Invalid start IP");
-                return;
-            }
-            if (IPAddress.TryParse(textBoxEndIP.Text, out tmp) == false)
-            {
-                MessageBox.Show("Invalid end IP");
+                MessageBox.Show(rangeError);
                 return;
             }
             int retriesCount;
-            if (int.TryParse(textBoxBoxScannerRetries.Text, out retriesCount) == false)
+            if (int.TryParse(textBoxBoxScannerRetries.Text, out retriesCount) == false
+                || retriesCount < 1 || retriesCount > OBKScanner.MAX_LOOPS)
             {
-                MessageBox.Show("Invalid retries count");
+                MessageBox.Show("Loops must be between 1 and " + OBKScanner.MAX_LOOPS + ".");
                 return;
             }
-            if (int.TryParse(textBoxBoxScannerRetries.Text, out retriesCount) == false)
+            int workersCount;
+            if (int.TryParse(textBoxScannerThreads.Text, out workersCount) == false
+                || workersCount < 1 || workersCount > OBKScanner.MAX_WORKERS)
             {
-                MessageBox.Show("Invalid retries count");
-                return;
-            }
-            if(retriesCount < 1)
-            {
-                MessageBox.Show("It makes no sense to have less than 1 loops.");
+                MessageBox.Show("Threads must be between 1 and " + OBKScanner.MAX_WORKERS + ".");
                 return;
             }
 
@@ -70,7 +66,7 @@ namespace BK7231Flasher
             scan.setOnFinished(onScannerFinished);
             scan.setOnProgress(onScannerProgress);
             scan.setLoopsCount(retriesCount);
-            setMaxWorkersCountFromGUI();
+            scan.setMaxWorkers(workersCount);
             scan.startScan();
             buttonStartScan.Text = "Stop";
         }
@@ -152,7 +148,8 @@ namespace BK7231Flasher
             if (scan != null)
             {
                 int cnt;
-                if (int.TryParse(textBoxScannerThreads.Text, out cnt))
+                if (int.TryParse(textBoxScannerThreads.Text, out cnt)
+                    && cnt >= 1 && cnt <= OBKScanner.MAX_WORKERS)
                 {
                     scan.setMaxWorkers(cnt);
                 }

--- a/BK7231Flasher/FormMain_Net_Scanner.cs
+++ b/BK7231Flasher/FormMain_Net_Scanner.cs
@@ -75,7 +75,7 @@ namespace BK7231Flasher
             scan.setAttemptsCount(attemptsCount);
             scan.setMaxWorkers(workersCount);
             scan.startScan();
-            buttonStartScan.Text = "Stop";
+            buttonStartScan.Text = "Stop scan";
         }
 
         private void onScannerProgress(int done, int total, string comment)
@@ -88,7 +88,7 @@ namespace BK7231Flasher
                 });
                 return;
             }
-            labelScanState.Text = "Scan progress: " + done + "/" + total + " requests sent. "+comment;
+            labelScanState.Text = "Scan status: " + done + "/" + total + " requests sent. " + comment;
         }
 
         private void onScannerFinished(bool bInterrupted)
@@ -102,7 +102,7 @@ namespace BK7231Flasher
                 return;
             }
             scan = null;
-            buttonStartScan.Text = "Start";
+            buttonStartScan.Text = "Start scan";
         }
 
         private void onScannerFound(OBKDeviceAPI api)
@@ -136,6 +136,7 @@ namespace BK7231Flasher
                 listView1.Items.Add(new ListViewItem());
             }
             updateItem(exi, listView1.Items[exi.getUserIndex()]);
+            resizeScannerBuildColumn();
         }
 
         private OBKDeviceAPI findDeviceForIP(string s)
@@ -161,6 +162,23 @@ namespace BK7231Flasher
                     scan.setMaxWorkers(cnt);
                 }
             }
+        }
+        private void listView1_Resize(object sender, EventArgs e)
+        {
+            resizeScannerBuildColumn();
+        }
+        private void resizeScannerBuildColumn()
+        {
+            int fixedWidth = columnID.Width + columnHeader1.Width + columnHeader2.Width
+                + columnHeader3.Width + columnHeader4.Width;
+            int availableWidth = listView1.ClientSize.Width - fixedWidth - 2;
+            if (listView1.Items.Count > 0
+                && listView1.Items[listView1.Items.Count - 1].Bounds.Bottom
+                    > listView1.ClientSize.Height)
+            {
+                availableWidth -= SystemInformation.VerticalScrollBarWidth;
+            }
+            columnHeader5.Width = Math.Max(100, availableWidth);
         }
         void updateItem(OBKDeviceAPI dev, ListViewItem it)
         {
@@ -307,8 +325,8 @@ namespace BK7231Flasher
                         StartIp = startIp,
                         EndIp = endIp,
                         SortOrder = wired ? 0 : 1,
-                        DisplayText = nic.Name + " (" + nic.NetworkInterfaceType + ", local " + address
-                            + ", /" + prefixLength + "): " + startIp + " - " + endIp,
+                        DisplayText = nic.Name + " — " + address + "/" + prefixLength
+                            + " (scan " + startIp + "–" + endIp + ")",
                     });
                 }
             }

--- a/BK7231Flasher/FormMain_Net_Scanner.cs
+++ b/BK7231Flasher/FormMain_Net_Scanner.cs
@@ -14,6 +14,7 @@ namespace BK7231Flasher
             public string DisplayText { get; set; }
             public string StartIp { get; set; }
             public string EndIp { get; set; }
+            public int SortOrder { get; set; }
         }
 
         OBKScanner scan;
@@ -180,7 +181,7 @@ namespace BK7231Flasher
 
             if (subnets.Count == 0)
             {
-                MessageBox.Show("No local IPv4 subnets were detected on active network interfaces.");
+                MessageBox.Show("No supported Ethernet or Wi-Fi IPv4 subnets were detected.");
                 return;
             }
 
@@ -213,13 +214,14 @@ namespace BK7231Flasher
             textBoxEndIP.Text = subnet.EndIp;
         }
 
-        private List<ScannerSubnetChoice> getLocalScannerSubnets()
+        private static List<ScannerSubnetChoice> getLocalScannerSubnets()
         {
-            Dictionary<string, ScannerSubnetChoice> result = new Dictionary<string, ScannerSubnetChoice>();
+            List<ScannerSubnetChoice> result = new List<ScannerSubnetChoice>();
+            HashSet<string> seen = new HashSet<string>();
 
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
             {
-                if (nic.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                if (isScannerInterfaceType(nic.NetworkInterfaceType) == false)
                 {
                     continue;
                 }
@@ -256,24 +258,108 @@ namespace BK7231Flasher
                         continue;
                     }
 
-                    string subnetBase = bytes[0] + "." + bytes[1] + "." + bytes[2];
-                    if (result.ContainsKey(subnetBase))
+                    IPAddress mask = uni.IPv4Mask;
+                    if (mask == null)
                     {
                         continue;
                     }
 
-                    result[subnetBase] = new ScannerSubnetChoice
+                    uint addressValue = scannerIPv4ToUInt32(address);
+                    uint maskValue = scannerIPv4ToUInt32(mask);
+                    int prefixLength = getPrefixLength(maskValue);
+                    if (prefixLength < 0)
                     {
-                        StartIp = subnetBase + ".0",
-                        EndIp = subnetBase + ".255",
-                        DisplayText = subnetBase + ".0/24 (" + nic.Name + ", local " + address + ")",
-                    };
+                        continue;
+                    }
+
+                    uint network = addressValue & maskValue;
+                    uint broadcast = network | ~maskValue;
+                    if (broadcast - network <= 1)
+                    {
+                        continue;
+                    }
+
+                    uint firstHost = network + 1;
+                    uint lastHost = broadcast - 1;
+                    ulong addressCount = (ulong)lastHost - firstHost + 1;
+                    if (addressCount > OBKScanner.MAX_ADDRESSES)
+                    {
+                        continue;
+                    }
+
+                    string key = nic.Id + "|" + network + "|" + maskValue;
+                    if (seen.Add(key) == false)
+                    {
+                        continue;
+                    }
+
+                    string startIp = scannerUInt32ToIPv4(firstHost);
+                    string endIp = scannerUInt32ToIPv4(lastHost);
+                    bool wired = nic.NetworkInterfaceType != NetworkInterfaceType.Wireless80211;
+                    result.Add(new ScannerSubnetChoice
+                    {
+                        StartIp = startIp,
+                        EndIp = endIp,
+                        SortOrder = wired ? 0 : 1,
+                        DisplayText = nic.Name + " (" + nic.NetworkInterfaceType + ", local " + address
+                            + ", /" + prefixLength + "): " + startIp + " - " + endIp,
+                    });
                 }
             }
 
-            return result.Values
-                .OrderBy(s => s.StartIp, StringComparer.Ordinal)
+            return result
+                .OrderBy(s => s.SortOrder)
+                .ThenBy(s => s.DisplayText, StringComparer.Ordinal)
                 .ToList();
+        }
+
+        private static bool isScannerInterfaceType(NetworkInterfaceType type)
+        {
+            return type == NetworkInterfaceType.Ethernet
+                || type == NetworkInterfaceType.FastEthernetFx
+                || type == NetworkInterfaceType.FastEthernetT
+                || type == NetworkInterfaceType.GigabitEthernet
+                || type == NetworkInterfaceType.Wireless80211;
+        }
+
+        private static uint scannerIPv4ToUInt32(IPAddress address)
+        {
+            byte[] bytes = address.GetAddressBytes();
+            return ((uint)bytes[0] << 24)
+                | ((uint)bytes[1] << 16)
+                | ((uint)bytes[2] << 8)
+                | bytes[3];
+        }
+
+        private static string scannerUInt32ToIPv4(uint address)
+        {
+            return ((address >> 24) & 0xFF) + "."
+                + ((address >> 16) & 0xFF) + "."
+                + ((address >> 8) & 0xFF) + "."
+                + (address & 0xFF);
+        }
+
+        private static int getPrefixLength(uint mask)
+        {
+            int prefixLength = 0;
+            bool foundZero = false;
+            for (int bit = 31; bit >= 0; bit--)
+            {
+                bool isSet = (mask & (1u << bit)) != 0;
+                if (isSet)
+                {
+                    if (foundZero)
+                    {
+                        return -1;
+                    }
+                    prefixLength++;
+                }
+                else
+                {
+                    foundZero = true;
+                }
+            }
+            return prefixLength;
         }
     }
 }

--- a/BK7231Flasher/FormMain_Net_Scanner.cs
+++ b/BK7231Flasher/FormMain_Net_Scanner.cs
@@ -28,6 +28,11 @@ namespace BK7231Flasher
                 scan.requestStop();
             }
         }
+        private void clearScannerResults()
+        {
+            founds.Clear();
+            listView1.Items.Clear();
+        }
         private void startOrStopScannerThread()
         {
             if (scan != null)
@@ -60,6 +65,7 @@ namespace BK7231Flasher
                 return;
             }
 
+            clearScannerResults();
             scan = new OBKScanner(textBoxStartIP.Text, textBoxEndIP.Text);
             scan.setUser(textBoxIPScannerUser.Text);
             scan.setPassword(textBoxIPScannerPass.Text);

--- a/BK7231Flasher/FormMain_Net_Scanner.cs
+++ b/BK7231Flasher/FormMain_Net_Scanner.cs
@@ -45,11 +45,11 @@ namespace BK7231Flasher
                 MessageBox.Show(rangeError);
                 return;
             }
-            int retriesCount;
-            if (int.TryParse(textBoxBoxScannerRetries.Text, out retriesCount) == false
-                || retriesCount < 1 || retriesCount > OBKScanner.MAX_LOOPS)
+            int attemptsCount;
+            if (int.TryParse(textBoxBoxScannerRetries.Text, out attemptsCount) == false
+                || attemptsCount < 1 || attemptsCount > OBKScanner.MAX_ATTEMPTS)
             {
-                MessageBox.Show("Loops must be between 1 and " + OBKScanner.MAX_LOOPS + ".");
+                MessageBox.Show("Attempts must be between 1 and " + OBKScanner.MAX_ATTEMPTS + ".");
                 return;
             }
             int workersCount;
@@ -66,7 +66,7 @@ namespace BK7231Flasher
             scan.setOnDeviceFound(onScannerFound);
             scan.setOnFinished(onScannerFinished);
             scan.setOnProgress(onScannerProgress);
-            scan.setLoopsCount(retriesCount);
+            scan.setAttemptsCount(attemptsCount);
             scan.setMaxWorkers(workersCount);
             scan.startScan();
             buttonStartScan.Text = "Stop";

--- a/BK7231Flasher/Misc/MySettings.cs
+++ b/BK7231Flasher/Misc/MySettings.cs
@@ -68,6 +68,8 @@ namespace BK7231Flasher
 
         public bool HasKey(string key) => SettingsList.ContainsKey(key);
 
+        public bool RemoveKey(string key) => SettingsList.Remove(key);
+
         public static MySettings CreateAndLoad(string fileName)
         {
             MySettings settings = new MySettings();

--- a/BK7231Flasher/Misc/OBKDeviceAPI.cs
+++ b/BK7231Flasher/Misc/OBKDeviceAPI.cs
@@ -150,33 +150,25 @@ namespace BK7231Flasher
         internal BKType getBKType()
         {
             string cs = getChipSet();
-            switch(cs)
+            if (Enum.TryParse(cs, true, out BKType type)
+                && type != BKType.Detect
+                && type != BKType.Invalid)
             {
-                case "BK7231T":
-                    return BKType.BK7231T;
-                case "BK7231U":
-                    return BKType.BK7231U;
-                case "BK7231N":
-                    return BKType.BK7231N;
-                case "BK7236":
-                    return BKType.BK7236;
-                case "BK7238":
-                    return BKType.BK7238;
-                case "BK7252":
-                    return BKType.BK7252;
-                case "BK7252N":
-                    return BKType.BK7252N;
-                case "BK7258":
-                    return BKType.BK7258;
-                case "RTL8720D":
-                    return BKType.RTL8720D;
-                case "LN882H":
-                    return BKType.LN882H;
-                case "BL602":
-                    return BKType.BL602;
-                default:
-                    return BKType.Invalid;
+                return type;
             }
+
+            string platformType = TuyaModules.getTypeForPlatformName(cs);
+            if (platformType == nameof(BKType.Invalid))
+            {
+                platformType = TuyaModules.getTypeForPlatformName(cs.ToLowerInvariant());
+            }
+            if (Enum.TryParse(platformType, true, out type)
+                && type != BKType.Detect
+                && type != BKType.Invalid)
+            {
+                return type;
+            }
+            return BKType.Invalid;
         }
 
         private byte []sendGetInternal(string path)

--- a/BK7231Flasher/Misc/OBKDeviceAPI.cs
+++ b/BK7231Flasher/Misc/OBKDeviceAPI.cs
@@ -576,7 +576,7 @@ namespace BK7231Flasher
                     {
                         JsonObject jsonObject = sendGenericJSONGet("/api/info", out jsonText);
                         this.info = jsonObject;
-                        if (this.info == null)
+                        if (this.info != null)
                         {
                             break;
                         }

--- a/BK7231Flasher/Misc/OBKDeviceAPI.cs
+++ b/BK7231Flasher/Misc/OBKDeviceAPI.cs
@@ -187,6 +187,9 @@ namespace BK7231Flasher
                 string fullRequestText = "http://" + adr + path;
                 WebRequest request = WebRequest.Create(fullRequestText);
                 request.Timeout = webRequestTimeOut;
+                HttpWebRequest httpRequest = request as HttpWebRequest;
+                if (httpRequest != null)
+                    httpRequest.ReadWriteTimeout = webRequestTimeOut;
                 if (!ToggleAllowUnsafeHeaderParsing(true))
                 {
                     // Couldn't set flag. Log the fact, throw an exception or whatever.
@@ -597,6 +600,23 @@ namespace BK7231Flasher
                 cb(this);
             }
         }
+        private void ThreadSendGetInfoSafe(object ocb)
+        {
+            try
+            {
+                ThreadSendGetInfo(ocb);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Failed to get device info: " + ex.Message);
+                if (bGetInfoSuccess == false && bGetInfoFailed == false)
+                {
+                    bGetInfoFailed = true;
+                    ProcessJSONReply cb = ocb as ProcessJSONReply;
+                    cb?.Invoke(this);
+                }
+            }
+        }
         public void ThreadSendGetFlashChunk(object obj)
         {
             GetFlashChunkArguments arg = obj as GetFlashChunkArguments;
@@ -645,7 +665,7 @@ namespace BK7231Flasher
         }
         public void sendGetInfo(ProcessJSONReply cb)
         {
-            startThread(ThreadSendGetInfo, cb);
+            startThread(ThreadSendGetInfoSafe, cb);
         }
         public void sendGetFlashChunk(ProcessBytesReply cb, ProcessProgress cb_progress, int adr, int size)
         {

--- a/BK7231Flasher/Misc/OBKDeviceAPI.cs
+++ b/BK7231Flasher/Misc/OBKDeviceAPI.cs
@@ -638,6 +638,7 @@ namespace BK7231Flasher
                     arg.cb_progress(ofs - adr, end - adr);
                 }
                 string hexString = string.Format("/api/flash/{0:X}-{1:X}", ofs, nowLen);
+                bool chunkComplete = false;
                 for(int tr = 0; tr < maxAttempts; tr++)
                 {
                     //byte [] flash = sendGetInternal("/api/flash/1e3000-2000");
@@ -648,7 +649,13 @@ namespace BK7231Flasher
                         continue;
                     }
                     bw.Write(flash, 0, nowLen);
+                    chunkComplete = true;
                     break;
+                }
+                if (chunkComplete == false)
+                {
+                    arg.cb?.Invoke(null, 0);
+                    return;
                 }
             }
             if (arg.cb != null)

--- a/BK7231Flasher/Misc/OBKDeviceAPI.cs
+++ b/BK7231Flasher/Misc/OBKDeviceAPI.cs
@@ -21,9 +21,9 @@ namespace BK7231Flasher
         JsonObject info;
         JsonObject status;
         JsonObject statusSTS;
-        bool bGetInfoFailed;
+        volatile bool bGetInfoFailed;
         bool bTasmota;
-        bool bGetInfoSuccess = false;
+        volatile bool bGetInfoSuccess = false;
         int powerCount;
         int webRequestTimeOut = 3000;
         string userName, password;
@@ -454,7 +454,6 @@ namespace BK7231Flasher
                 {
                     jsonText = jsonText.Substring(0, lastBraceIndex + 1);
                 }
-                File.WriteAllText("lastHTTPJSONtext.txt", jsonText);
                 // RTL8710B returns 0. for %f printf
                 jsonText = jsonText.Replace("0.,", "0.0,");
                 jsonText = jsonText.Replace("0.}", "0.0}");
@@ -572,7 +571,7 @@ namespace BK7231Flasher
                 }
                 if (getSDK().ToLower() == "obk")
                 {
-                    this.bTasmota = true;
+                    this.bTasmota = false;
                     for (int att = 0; att < 4; att++)
                     {
                         JsonObject jsonObject = sendGenericJSONGet("/api/info", out jsonText);

--- a/BK7231Flasher/Misc/OBKMassBackup.cs
+++ b/BK7231Flasher/Misc/OBKMassBackup.cs
@@ -26,6 +26,8 @@ namespace BK7231Flasher
     class OBKMassBackup
     {
         public static string DEFAULT_BASE_DIR = "massNetworkBackups";
+        private const int COMMAND_WAIT_TIMEOUT_MS = 10000;
+        private const int FLASH_WAIT_TIMEOUT_MS = 60000;
 
         List<OBKDeviceAPI> devices = new List<OBKDeviceAPI>();
         Thread thread;
@@ -34,6 +36,8 @@ namespace BK7231Flasher
         string deviceDirName = "";
         MassBackupProgressUpdate onProgress;
         MassBackupFinished onFinished;
+        readonly ManualResetEventSlim downloadCompleted = new ManualResetEventSlim(false);
+        int activeDownloadGeneration;
 
         public void setOnProgress(MassBackupProgressUpdate cb)
         {
@@ -52,18 +56,38 @@ namespace BK7231Flasher
             thread = new Thread(workerThread);
             thread.Start();
         }
+        int beginDownload()
+        {
+            int generation = Interlocked.Increment(ref activeDownloadGeneration);
+            downloadCompleted.Reset();
+            downloadState = DownloadState.Pending;
+            return generation;
+        }
+        bool waitForDownload(int generation, int timeoutMS)
+        {
+            if (downloadCompleted.Wait(timeoutMS))
+            {
+                return downloadState == DownloadState.Ok;
+            }
+            if (Interlocked.CompareExchange(
+                ref activeDownloadGeneration, generation + 1, generation) == generation)
+            {
+                downloadState = DownloadState.Error;
+                onProgress?.Invoke("Timed out downloading " + downloadTarget
+                    + " for " + deviceDirName + ".");
+            }
+            return false;
+        }
         void processDeviceTASCommand(int index, string cmd, DownloadTarget dt)
         {
             OBKDeviceAPI dev = devices[index];
             downloadTarget = dt;
             for (int at = 0; at < 5; at++)
             {
-                downloadState = DownloadState.Pending;
-                dev.sendCmnd(cmd, onTasReplyTemplate);
-                while (downloadState == DownloadState.Pending)
-                {
-                    Thread.Sleep(100);
-                }
+                int generation = beginDownload();
+                dev.sendCmnd(cmd, (self, reply, replyText) =>
+                    onTasReplyTemplate(generation, self, reply, replyText));
+                waitForDownload(generation, COMMAND_WAIT_TIMEOUT_MS);
                 if (downloadState == DownloadState.Ok)
                 {
                     break;
@@ -82,40 +106,94 @@ namespace BK7231Flasher
             processDeviceTASCommand(index, "Status 0", DownloadTarget.TasmotaStatus0);
             processDeviceTASCommand(index, "Status 1", DownloadTarget.TasmotaStatus1);
         }
-        private void onTasReplyTemplate(OBKDeviceAPI self, JsonObject reply, string replyText)
+        private void onTasReplyTemplate(
+            int generation,
+            OBKDeviceAPI self,
+            JsonObject reply,
+            string replyText)
         {
-            if (reply != null)
+            if (generation != Volatile.Read(ref activeDownloadGeneration))
             {
-                downloadState = DownloadState.Ok;
-                string fileName = deviceDirName + "_" + downloadTarget.ToString() + ".txt";
-                File.WriteAllText(Path.Combine(deviceDirectory, fileName), replyText);
+                return;
             }
-            else
+            try
+            {
+                if (reply != null)
+                {
+                    string fileName = deviceDirName + "_" + downloadTarget.ToString() + ".txt";
+                    File.WriteAllText(Path.Combine(deviceDirectory, fileName), replyText);
+                    downloadState = DownloadState.Ok;
+                }
+                else
+                {
+                    downloadState = DownloadState.Error;
+                }
+            }
+            catch (Exception ex)
             {
                 downloadState = DownloadState.Error;
+                Console.WriteLine("Failed to save " + downloadTarget + ": " + ex.Message);
+            }
+            finally
+            {
+                if (generation == Volatile.Read(ref activeDownloadGeneration))
+                {
+                    downloadCompleted.Set();
+                }
             }
         }
         int stat_totalErrors;
         int stat_totalRetriesDone;
         DownloadState downloadState;
         DownloadTarget downloadTarget;
-        private void onGenericDownloadReady(byte[] data, int dataLen)
+        private void onGenericDownloadReady(
+            int generation,
+            int expectedLength,
+            byte[] data,
+            int dataLen)
         {
-            if(data == null || dataLen == 0)
+            if (generation != Volatile.Read(ref activeDownloadGeneration))
+            {
+                return;
+            }
+            try
+            {
+                if (data == null
+                    || dataLen != expectedLength
+                    || data.Length != expectedLength)
+                {
+                    downloadState = DownloadState.Error;
+                    Console.WriteLine("Device: " + deviceDirName + ", mode "
+                        + downloadTarget + ", incomplete download!");
+                }
+                else
+                {
+                    string fileName = deviceDirName + "_" + downloadTarget.ToString() + ".bin";
+                    Console.WriteLine("Device: " + deviceDirName + ", mode "
+                        + downloadTarget + ", saving result to file...");
+                    File.WriteAllBytes(Path.Combine(deviceDirectory,fileName), data);
+                    downloadState = DownloadState.Ok;
+                }
+            }
+            catch (Exception ex)
             {
                 downloadState = DownloadState.Error;
-                Console.WriteLine("Device: " + deviceDirName + ", mode " + downloadTarget + ", error!");
+                Console.WriteLine("Failed to save " + downloadTarget + ": " + ex.Message);
             }
-            else
+            finally
             {
-                downloadState = DownloadState.Ok;
-                string fileName = deviceDirName + "_" + downloadTarget.ToString() + ".bin";
-                Console.WriteLine("Device: " + deviceDirName + ", mode " + downloadTarget + ", saving result to file...");
-                File.WriteAllBytes(Path.Combine(deviceDirectory,fileName), data);
+                if (generation == Volatile.Read(ref activeDownloadGeneration))
+                {
+                    downloadCompleted.Set();
+                }
             }
         }
-        private void onGenericProgress(int done, int total)
+        private void onGenericProgress(int generation, int done, int total)
         {
+            if (generation != Volatile.Read(ref activeDownloadGeneration))
+            {
+                return;
+            }
             string stat = "Downloading " + downloadTarget.ToString() + " for " + deviceDirName
                 + " progress " + done + "/" + total;
             stat += ", total fatal download errors so far: " + stat_totalErrors + ", retries " + stat_totalRetriesDone;
@@ -131,23 +209,43 @@ namespace BK7231Flasher
             OBKDeviceAPI dev = devices[index];
             for (int mode = 0; mode < 2; mode++)
             {
+                int expectedLength;
+                if (mode == 0)
+                {
+                    OBKFlashLayout.getConfigLocation(dev.getBKType(), out int sectors);
+                    expectedLength = sectors * BK7231Flasher.SECTOR_SIZE;
+                }
+                else
+                {
+                    expectedLength = TuyaConfig.getMagicSize(dev.getBKType());
+                }
+                if (expectedLength <= 0)
+                {
+                    stat_totalErrors++;
+                    faileds++;
+                    continue;
+                }
                 for (int attempt = 0; attempt < 8; attempt++)
                 {
-                    downloadState = DownloadState.Pending;
+                    downloadTarget = mode == 0
+                        ? DownloadTarget.OBKConfig
+                        : DownloadTarget.TuyaConfig;
+                    int generation = beginDownload();
                     if(mode == 0)
                     {
-                        downloadTarget = DownloadTarget.OBKConfig;
-                        dev.sendGetFlashChunk_OBKConfig(onGenericDownloadReady, onGenericProgress);
+                        dev.sendGetFlashChunk_OBKConfig(
+                            (data, dataLen) => onGenericDownloadReady(
+                                generation, expectedLength, data, dataLen),
+                            (done, total) => onGenericProgress(generation, done, total));
                     }
                     else
                     {
-                        downloadTarget = DownloadTarget.TuyaConfig;
-                        dev.sendGetFlashChunk_TuyaCFGFromOBKDevice(onGenericDownloadReady, onGenericProgress);
+                        dev.sendGetFlashChunk_TuyaCFGFromOBKDevice(
+                            (data, dataLen) => onGenericDownloadReady(
+                                generation, expectedLength, data, dataLen),
+                            (done, total) => onGenericProgress(generation, done, total));
                     }
-                    while (downloadState == DownloadState.Pending)
-                    {
-                        Thread.Sleep(100);
-                    }
+                    waitForDownload(generation, FLASH_WAIT_TIMEOUT_MS);
                     if (downloadState == DownloadState.Ok)
                     {
                         break;

--- a/BK7231Flasher/Misc/OBKMassBackup.cs
+++ b/BK7231Flasher/Misc/OBKMassBackup.cs
@@ -25,7 +25,7 @@ namespace BK7231Flasher
     public delegate void MassBackupFinished(int totalErrors, int totalRetries);
     class OBKMassBackup
     {
-        public static string DEFAULT_BASE_DIR = "massNetworkBackups";
+        public static string DEFAULT_BASE_DIR = Path.Combine("backups", "massNetworkBackups");
         private const int COMMAND_WAIT_TIMEOUT_MS = 10000;
         private const int FLASH_WAIT_TIMEOUT_MS = 60000;
 
@@ -221,8 +221,11 @@ namespace BK7231Flasher
                 }
                 if (expectedLength <= 0)
                 {
-                    stat_totalErrors++;
-                    faileds++;
+                    downloadTarget = mode == 0
+                        ? DownloadTarget.OBKConfig
+                        : DownloadTarget.TuyaConfig;
+                    onProgress?.Invoke("Skipping " + downloadTarget + " for " + deviceDirName
+                        + ": this backup is not supported for " + dev.getChipSet() + ".");
                     continue;
                 }
                 for (int attempt = 0; attempt < 8; attempt++)

--- a/BK7231Flasher/Misc/OBKScanner.cs
+++ b/BK7231Flasher/Misc/OBKScanner.cs
@@ -13,13 +13,13 @@ namespace BK7231Flasher
     public class OBKScanner
     {
         internal const int MAX_WORKERS = 128;
-        internal const int MAX_LOOPS = 20;
+        internal const int MAX_ATTEMPTS = 20;
         internal const ulong MAX_ADDRESSES = 65536;
 
         int maxWorkers = 8;
 
 
-        int loopsCount = 2;
+        int attemptsCount = 1;
         string startIP, endIP;
         Thread thread;
         volatile bool bWantStop;
@@ -65,13 +65,13 @@ namespace BK7231Flasher
             thread.Start();
         }
 
-        internal void setLoopsCount(int nct)
+        internal void setAttemptsCount(int count)
         {
-            if (nct < 1 || nct > MAX_LOOPS)
+            if (count < 1 || count > MAX_ATTEMPTS)
             {
-                throw new ArgumentOutOfRangeException(nameof(nct));
+                throw new ArgumentOutOfRangeException(nameof(count));
             }
-            this.loopsCount = nct;
+            this.attemptsCount = count;
         }
 
         internal void setUser(string text)
@@ -102,68 +102,73 @@ namespace BK7231Flasher
                 return;
             }
 
-            int total = (int)(((ulong)end - start + 1) * (ulong)loopsCount);
+            List<string> addressesToCheck = new List<string>();
+            uint current = start;
+            while (true)
+            {
+                addressesToCheck.Add(uint32ToIPv4(current));
+                if (current == end)
+                {
+                    break;
+                }
+                current++;
+            }
+
+            int total = addressesToCheck.Count;
             int done = 0;
             callOnProgress(done, total,"Starting scan...");
-            for(int loop = 0; loop < loopsCount && bWantStop == false; loop++)
+            for (int attempt = 0;
+                attempt < attemptsCount && addressesToCheck.Count > 0 && bWantStop == false;
+                attempt++)
             {
-                uint current = start;
-                while (true)
+                List<string> retryAddresses =
+                    attempt + 1 < attemptsCount ? new List<string>() : null;
+                foreach (string nextIPstr in addressesToCheck)
                 {
                     if (bWantStop)
                     {
                         break;
                     }
-                    OBKDeviceAPI worker = getWorker();
-                    if (worker == null)
+                    OBKDeviceAPI worker;
+                    while ((worker = getWorker(retryAddresses)) == null && bWantStop == false)
                     {
                         Thread.Sleep(100);
-                        continue;
+                    }
+                    if (bWantStop)
+                    {
+                        break;
                     }
                     Thread.Sleep(50);
-                    int scannerTimeOutMS;
-                    if(loopsCount <= 1)
-                    {
-                        scannerTimeOutMS = 5000;
-                    }
-                    else
-                    {
-                        if(loop == 0)
-                        {
-                            scannerTimeOutMS = 2000;
-                        }
-                        else
-                        {
-                            scannerTimeOutMS = 5000 + 500 * loop;
-                        }
-                    }
-                    byte[] bytes = BitConverter.GetBytes(current);
-                    Array.Reverse(bytes);
-                    IPAddress ip = new IPAddress(bytes);
-                    string nextIPstr = ip.ToString();
+                    int scannerTimeOutMS =
+                        attempt == 0 ? 2000 : 5000 + 500 * (attempt - 1);
                     Console.WriteLine("Will try to check " + nextIPstr);
                     worker.clear();
                     worker.setPassword(password);
                     worker.setUser(userName);
-                    worker.setAdr(ip.ToString());
+                    worker.setAdr(nextIPstr);
                     worker.setWebRequestTimeOut(scannerTimeOutMS);
                     worker.sendGetInfo(null);
                     done++;
-                    callOnProgress(done, total, "Checked "+nextIPstr+"...");
-                    if (current == end)
-                    {
-                        break;
-                    }
-                    current++;
+                    callOnProgress(done, total, "Checked " + nextIPstr + "...");
                 }
-            }
-            if (bWantStop == false)
-            {
-                drainWorkers();
-            }
-            else
-            {
-                processCompletedWorkers();
+                if (bWantStop == false)
+                {
+                    drainWorkers(retryAddresses);
+                }
+                else
+                {
+                    processCompletedWorkers(null);
+                }
+                if (retryAddresses != null)
+                {
+                    addressesToCheck = retryAddresses;
+                    if (retryAddresses.Count > 0 && bWantStop == false)
+                    {
+                        total += retryAddresses.Count;
+                        callOnProgress(done, total,
+                            "Retrying " + retryAddresses.Count + " address(es)...");
+                    }
+                }
             }
             callOnProgress(done, total, bWantStop ? "Stopped." : "All done.");
             onScanFinished?.Invoke(bWantStop);
@@ -213,15 +218,23 @@ namespace BK7231Flasher
                 | bytes[3];
         }
 
-        private void drainWorkers()
+        private static string uint32ToIPv4(uint address)
         {
-            while (bWantStop == false && processCompletedWorkers())
+            return ((address >> 24) & 0xFF) + "."
+                + ((address >> 16) & 0xFF) + "."
+                + ((address >> 8) & 0xFF) + "."
+                + (address & 0xFF);
+        }
+
+        private void drainWorkers(List<string> retryAddresses)
+        {
+            while (bWantStop == false && processCompletedWorkers(retryAddresses))
             {
                 Thread.Sleep(50);
             }
         }
 
-        private bool processCompletedWorkers()
+        private bool processCompletedWorkers(List<string> retryAddresses)
         {
             bool hasPendingWorkers = false;
             for (int i = workers.Count - 1; i >= 0; i--)
@@ -234,6 +247,7 @@ namespace BK7231Flasher
                 }
                 else if (worker.getInfoFailed())
                 {
+                    retryAddresses?.Add(worker.getAdr());
                     workers.RemoveAt(i);
                 }
                 else
@@ -244,7 +258,7 @@ namespace BK7231Flasher
             return hasPendingWorkers;
         }
 
-        private OBKDeviceAPI getWorker()
+        private OBKDeviceAPI getWorker(List<string> retryAddresses)
         {
             for(int i = 0; i < workers.Count; i++)
             {
@@ -257,6 +271,7 @@ namespace BK7231Flasher
                 }
                 if (d.getInfoFailed())
                 {
+                    retryAddresses?.Add(d.getAdr());
                     return d;
                 }
             }

--- a/BK7231Flasher/Misc/OBKScanner.cs
+++ b/BK7231Flasher/Misc/OBKScanner.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 
 namespace BK7231Flasher
@@ -11,13 +12,17 @@ namespace BK7231Flasher
 
     public class OBKScanner
     {
+        internal const int MAX_WORKERS = 128;
+        internal const int MAX_LOOPS = 20;
+        internal const ulong MAX_ADDRESSES = 65536;
+
         int maxWorkers = 8;
 
 
         int loopsCount = 2;
         string startIP, endIP;
         Thread thread;
-        bool bWantStop;
+        volatile bool bWantStop;
         List<OBKDeviceAPI> workers = new List<OBKDeviceAPI>();
         OBKScannerFoundDevice onDeviceFound;
         OBKScannerFinished onScanFinished;
@@ -48,6 +53,10 @@ namespace BK7231Flasher
         }
         public void setMaxWorkers(int max)
         {
+            if (max < 1 || max > MAX_WORKERS)
+            {
+                throw new ArgumentOutOfRangeException(nameof(max));
+            }
             this.maxWorkers = max;
         }
         public void startScan()
@@ -58,6 +67,10 @@ namespace BK7231Flasher
 
         internal void setLoopsCount(int nct)
         {
+            if (nct < 1 || nct > MAX_LOOPS)
+            {
+                throw new ArgumentOutOfRangeException(nameof(nct));
+            }
             this.loopsCount = nct;
         }
 
@@ -79,23 +92,23 @@ namespace BK7231Flasher
         }
         void scanThread()
         {
-            IPAddress startAddress = IPAddress.Parse(startIP);
-            IPAddress endAddress = IPAddress.Parse(endIP);
+            uint start;
+            uint end;
+            string rangeError;
+            if (tryParseRange(startIP, endIP, out start, out end, out rangeError) == false)
+            {
+                callOnProgress(0, 0, rangeError);
+                onScanFinished?.Invoke(true);
+                return;
+            }
 
-            byte[] startBytes = startAddress.GetAddressBytes();
-            byte[] endBytes = endAddress.GetAddressBytes();
-
-            Array.Reverse(startBytes);
-            Array.Reverse(endBytes);
-            uint start = BitConverter.ToUInt32(startBytes, 0);
-            uint end = BitConverter.ToUInt32(endBytes, 0);
-            int total = (((int)end - (int)start)+1) * loopsCount;
+            int total = (int)(((ulong)end - start + 1) * (ulong)loopsCount);
             int done = 0;
             callOnProgress(done, total,"Starting scan...");
-            for(int loop = 0; loop < loopsCount; loop++)
+            for(int loop = 0; loop < loopsCount && bWantStop == false; loop++)
             {
                 uint current = start;
-                while (current <= end)
+                while (true)
                 {
                     if (bWantStop)
                     {
@@ -135,13 +148,100 @@ namespace BK7231Flasher
                     worker.setAdr(ip.ToString());
                     worker.setWebRequestTimeOut(scannerTimeOutMS);
                     worker.sendGetInfo(null);
-                    current++;
                     done++;
                     callOnProgress(done, total, "Checked "+nextIPstr+"...");
+                    if (current == end)
+                    {
+                        break;
+                    }
+                    current++;
                 }
             }
-            callOnProgress(total, total, "All done.");
-            onScanFinished(bWantStop);
+            if (bWantStop == false)
+            {
+                drainWorkers();
+            }
+            else
+            {
+                processCompletedWorkers();
+            }
+            callOnProgress(done, total, bWantStop ? "Stopped." : "All done.");
+            onScanFinished?.Invoke(bWantStop);
+        }
+
+        internal static bool tryParseRange(string startText, string endText,
+            out uint start, out uint end, out string error)
+        {
+            start = 0;
+            end = 0;
+            error = null;
+            IPAddress address;
+            if (IPAddress.TryParse(startText?.Trim(), out address) == false
+                || address.AddressFamily != AddressFamily.InterNetwork)
+            {
+                error = "Invalid start IPv4 address.";
+                return false;
+            }
+            start = ipv4ToUInt32(address);
+            if (IPAddress.TryParse(endText?.Trim(), out address) == false
+                || address.AddressFamily != AddressFamily.InterNetwork)
+            {
+                error = "Invalid end IPv4 address.";
+                return false;
+            }
+            end = ipv4ToUInt32(address);
+            if (end < start)
+            {
+                error = "End IP must not be before start IP.";
+                return false;
+            }
+            ulong addressCount = (ulong)end - start + 1;
+            if (addressCount > MAX_ADDRESSES)
+            {
+                error = "IP range is too large. The maximum is " + MAX_ADDRESSES + " addresses.";
+                return false;
+            }
+            return true;
+        }
+
+        private static uint ipv4ToUInt32(IPAddress address)
+        {
+            byte[] bytes = address.GetAddressBytes();
+            return ((uint)bytes[0] << 24)
+                | ((uint)bytes[1] << 16)
+                | ((uint)bytes[2] << 8)
+                | bytes[3];
+        }
+
+        private void drainWorkers()
+        {
+            while (bWantStop == false && processCompletedWorkers())
+            {
+                Thread.Sleep(50);
+            }
+        }
+
+        private bool processCompletedWorkers()
+        {
+            bool hasPendingWorkers = false;
+            for (int i = workers.Count - 1; i >= 0; i--)
+            {
+                OBKDeviceAPI worker = workers[i];
+                if (worker.hasBasicInfoReceived())
+                {
+                    processFoundDevice(worker);
+                    workers.RemoveAt(i);
+                }
+                else if (worker.getInfoFailed())
+                {
+                    workers.RemoveAt(i);
+                }
+                else
+                {
+                    hasPendingWorkers = true;
+                }
+            }
+            return hasPendingWorkers;
         }
 
         private OBKDeviceAPI getWorker()


### PR DESCRIPTION
## Summary

- validate ordered IPv4 scan ranges and reject IPv6 input
- cap scans at 65,536 addresses, 20 loops, and 128 workers
- safely handle ranges ending at `255.255.255.255` without integer wraparound
- drain outstanding HTTP workers before reporting a normal scan as complete
- make worker completion and stop flags visible across threads
- make right-click actions target the row under the pointer and ignore empty list space
- remove the unconditional shared `lastHTTPJSONtext.txt` write from discovery parsing
- correctly classify `SDK=obk` devices as OBK while retaining Tasmota discovery

## Why

The scanner could report completion before its final HTTP requests were consumed, so responsive devices at the end of a scan could be omitted. Input values were effectively unbounded, right-click actions could use a stale focused row, and concurrent discovery depended on writing every JSON response to one shared debug filename.

OBK and Tasmota discovery both begin with the Tasmota-compatible `STATUS 0` endpoint. The OBK branch was nevertheless setting the Tasmota flag to `true`, which routed OBK devices through the Tasmota mass-backup path.

## Impact

Scans now finish with complete results, reject unsafe ranges and concurrency settings, and apply context-menu actions to the intended device. OBK devices follow the OBK backup path, while genuine Tasmota devices remain classified as Tasmota.

## Validation

- Release build completed with 0 errors
- range and worker-cap boundary tests passed
- one-address live OBK scan completed with exactly one callback and no stranded workers
- discovery succeeded while `lastHTTPJSONtext.txt` was held exclusively open
- live `/24` scan found 8 compatible devices: 7 OBK and 1 genuine Tasmota, all classified correctly
- mock Tasmota response remained classified as Tasmota
- hardware checks used only read-only `STATUS 0` and `/api/info` requests; no reboot or control commands were sent
- CRLF-aware diff check passed, with normal and EOL-ignoring numstats matching